### PR TITLE
Add :<aligner>1m suffix for aggregated metrics.

### DIFF
--- a/collectors/monitoring_metrics.go
+++ b/collectors/monitoring_metrics.go
@@ -14,6 +14,7 @@
 package collectors
 
 import (
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -72,8 +73,11 @@ type HistogramMetric struct {
 	keysHash uint64
 }
 
-func (t *TimeSeriesMetrics) CollectNewConstHistogram(timeSeries *monitoring.TimeSeries, reportTime time.Time, labelKeys []string, dist *monitoring.Distribution, buckets map[float64]uint64, labelValues []string) {
+func (t *TimeSeriesMetrics) CollectNewConstHistogram(timeSeries *monitoring.TimeSeries, reportTime time.Time, labelKeys []string, dist *monitoring.Distribution, buckets map[float64]uint64, labelValues []string, align string) {
 	fqName := buildFQName(timeSeries)
+	if align != "ALIGN_NONE" {
+		fqName += ":" + strings.TrimLeft(strings.ToLower(align), "align_")
+	}
 
 	if t.fillMissingLabels {
 		vs, ok := t.histogramMetrics[fqName]
@@ -109,8 +113,11 @@ func (t *TimeSeriesMetrics) newConstHistogram(fqName string, reportTime time.Tim
 	)
 }
 
-func (t *TimeSeriesMetrics) CollectNewConstMetric(timeSeries *monitoring.TimeSeries, reportTime time.Time, labelKeys []string, metricValueType prometheus.ValueType, metricValue float64, labelValues []string) {
+func (t *TimeSeriesMetrics) CollectNewConstMetric(timeSeries *monitoring.TimeSeries, reportTime time.Time, labelKeys []string, metricValueType prometheus.ValueType, metricValue float64, labelValues []string, align string) {
 	fqName := buildFQName(timeSeries)
+	if align != "ALIGN_NONE" {
+		fqName += ":" + strings.TrimLeft(strings.ToLower(align), "align_")
+	}
 
 	if t.fillMissingLabels {
 		vs, ok := t.constMetrics[fqName]


### PR DESCRIPTION
If aggregation is used for metrics (enabled via prefix) add
corresponding suffix + 1m (our hardcoded aggregation interval) to metric
name.

Example:

Flag:
`--monitoring.metrics-type-prefixes='align_rate:compute.googleapis.com/instance/disk/throttled_read_ops_count'`

Metric name:
```
stackdriver_gce_instance_compute_googleapis_com_instance_disk_throttled_read_ops_count:rate1m
```